### PR TITLE
Feature/endpoint to check if dataset exists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>war</packaging>
 
 
-    <version>3.1.13</version>
+    <version>3.1.14-SNAPSHOT</version>
     <name>Service :: IntAct Editor</name>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <!-- UTF-8 encoding to generate the build-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.build.timestam00p.format>yyyyMMdd-HHmm</maven.build.timestam00p.format>
+        <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
         <spring.version>3.2.9.RELEASE</spring.version>
@@ -35,7 +35,7 @@
         <psi.jami.version>3.2.12</psi.jami.version>
         <!--The version needs to be the same than in intact-dataexchange to avoid problems-->
         <intact.jami.version>1.3.15</intact.jami.version>
-        <dataexchange.version>3.0.56</dataexchange.version>
+        <dataexchange.version>3.0.57-SNAPSHOT</dataexchange.version>
         <intact.tools.version>1.0.25</intact.tools.version>
         <h2.version>1.3.162</h2.version>
         <intact.primefaces.version>3.1.1-intact-SNAPSHOT</intact.primefaces.version>

--- a/src/main/java/uk/ac/ebi/intact/editor/controller/curate/feature/FeatureShortlabelGeneratorListener.java
+++ b/src/main/java/uk/ac/ebi/intact/editor/controller/curate/feature/FeatureShortlabelGeneratorListener.java
@@ -3,8 +3,6 @@ package uk.ac.ebi.intact.editor.controller.curate.feature;
 import uk.ac.ebi.intact.tools.feature.shortlabel.generator.events.*;
 import uk.ac.ebi.intact.tools.feature.shortlabel.generator.listener.ShortlabelGeneratorListener;
 
-import javax.xml.ws.Feature;
-
 /**
  * Created by Maximilian Koch (mkoch@ebi.ac.uk).
  */

--- a/src/main/java/uk/ac/ebi/intact/editor/ws/MiExportService.java
+++ b/src/main/java/uk/ac/ebi/intact/editor/ws/MiExportService.java
@@ -40,6 +40,10 @@ public interface MiExportService {
     String FORMAT_FEBS_SDA = "sda";
 
     @GET
+    @Path("/publication-imex/ac")
+    Object getPublicationAcFromImexId(@QueryParam("imex") String imexId);
+
+    @GET
     @Path("/publication-imex")
     Object exportPublicationFromImexId(@QueryParam("imex") String imexId,
                              @DefaultValue("tab25") @QueryParam("format") String format);
@@ -64,9 +68,9 @@ public interface MiExportService {
     Object exportComplex(@QueryParam("ac") String id,
                              @DefaultValue("xml254") @QueryParam("format") String format);
 
-    public void writeEvidences(OutputStream outputStream, String format, String countQuery, String query,
+    void writeEvidences(OutputStream outputStream, String format, String countQuery, String query,
                       Map<String, Object> parameters) throws IOException;
-    public void writeComplexes(OutputStream outputStream, String format, String countQuery, String query,
+    void writeComplexes(OutputStream outputStream, String format, String countQuery, String query,
                                Map<String, Object> parameters) throws IOException;
 
 }


### PR DESCRIPTION
New endpoint `.../publication-imex/ac` to check if a publication exists and get its AC from its IMEX id. This will be used to check publications curated in Intact when searching in imex consortium.

Currently we make a call to export the publication just to check if it exists and we ignore the response, so we don't need to actually do any export, we just need to get the publication and return a 200.